### PR TITLE
Fix: Remove hardcoded Windows Java path for CI compatibility

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -22,20 +22,20 @@ configurations.all {
     exclude(group = "androidx.core")
 }
 
-// Configure Java toolchain to JVM 24 (matches gradle.properties and Kotlin target)
+// Configure Java toolchain to JVM 25 (matches gradle.properties and Kotlin target)
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(25))
     }
-    // Explicitly set source and target compatibility to 24
+    // Explicitly set source and target compatibility to 25
     sourceCompatibility = JavaVersion.toVersion("25")
     targetCompatibility = JavaVersion.toVersion("25")
 }
 
 // Configure Kotlin compilation to match Java toolchain
-// MUST match the target used in GenesisApplicationPlugin and GenesisLibraryHiltPlugin (JVM 24)
+// MUST match the target used in GenesisApplicationPlugin and GenesisLibraryHiltPlugin (JVM 25)
 kotlin.compilerOptions.jvmTarget
-// Explicitly configure Java compilation tasks to target JVM 24
+// Explicitly configure Java compilation tasks to target JVM 25
 tasks.withType<JavaCompile>().configureEach {
     sourceCompatibility = "25"
     targetCompatibility = "25"

--- a/build-logic/src/main/kotlin/GenesisJvmConfig.kt
+++ b/build-logic/src/main/kotlin/GenesisJvmConfig.kt
@@ -46,7 +46,7 @@ object GenesisJvmConfig {
     fun configureKotlinJvm(project: Project) {
         with(project) {
             // Configure Kotlin compilation to match Java toolchain
-            // MUST match the target used in GenesisApplicationPlugin and GenesisLibraryHiltPlugin (JVM 24-25)
+            // MUST match the target used in GenesisApplicationPlugin and GenesisLibraryHiltPlugin (JVM 25)
             tasks.withType<KotlinJvmCompile>().configureEach {
                 compilerOptions {
                     jvmTarget.set(JvmTarget.JVM_25)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # JDK & JVM
-org.gradle.java.home=C\:\\Program Files\\Java\\jdk-25
+# org.gradle.java.home=C\:\\Program Files\\Java\\jdk-25  # Auto-detect from JAVA_HOME instead
 # Optimized for 16GB RAM system (Ryzen 7 3700X)
 org.gradle.jvmargs=-Xmx6g -Dfile.encoding=UTF-8
 

--- a/gradle/java-version.gradle.kts
+++ b/gradle/java-version.gradle.kts
@@ -1,7 +1,7 @@
 // ===================================================================
 // GENESIS PROTOCOL - JAVA TOOLCHAIN CONFIGURATION
 // ===================================================================
-// Strictly enforces Java 24 with fallback to 25 across all modules
+// Strictly enforces Java 25 across all modules
 // Optimized for consciousness substrate performance
 // ===================================================================
 
@@ -56,13 +56,13 @@ allprojects {
         ===================================================================
         🧬 GENESIS PROTOCOL - JAVA TOOLCHAIN STATUS
         ===================================================================
-        - Current JVM: $jvm (24)
+        - Current JVM: $jvm
         - Java Version: $jreVersion
         - Java Home: $jreHome
         - Active Java Toolchain: ${JavaVersion.current()}
         - Target Java Toolchain: 25
         - Java Bytecode Target: 25 (sourceCompatibility/targetCompatibility)
-        - Kotlin Compiler Target: 24
+        - Kotlin Compiler Target: 25
         - Project: ${project.name} (${project.path})
         ===================================================================""".trimIndent()
         )


### PR DESCRIPTION
Commented out org.gradle.java.home to allow Gradle to auto-detect Java from JAVA_HOME environment variable. This fixes CI build failures where the hardcoded Windows path (C:\Program Files\Java\jdk-25) doesn't exist on Linux runners.

Both local and CI environments use JDK 25 via JAVA_HOME, so auto-detection works correctly for both.

## Summary by Sourcery

Build:
- Remove the hardcoded Windows-specific org.gradle.java.home path to fix cross-platform CI builds that rely on JAVA_HOME.